### PR TITLE
feat(filer/empty-number): show a default value for databound numbers whe...

### DIFF
--- a/src/coreos.js
+++ b/src/coreos.js
@@ -24,7 +24,7 @@ angular.module('coreos.ui', [
   'd3',
   'ui.bootstrap'
 ]);
-angular.module('coreos.filters', []);
+angular.module('coreos.filters', ['underscore']);
 angular.module('coreos.events', []);
 angular.module('coreos', [
   'coreos.events',

--- a/src/filter/empty-number.js
+++ b/src/filter/empty-number.js
@@ -1,0 +1,17 @@
+'use strict';
+angular.module('coreos.filters').filter('coEmptyNumber', function(_) {
+
+  /**
+   * Replaces an expected numeric value with the default text if the value is
+   * not a number.
+   */
+  return function(val, text) {
+    var defaultText = '&ndash;',
+        replacementText = text || defaultText;
+    if (_.isNaN(val) || _.isNull(val) || _.isUndefined(val)) {
+      return replacementText;
+    }
+    return val.toString();
+  };
+
+});

--- a/src/filter/empty-number.test.js
+++ b/src/filter/empty-number.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+describe('coreos.filters.coEmptyNumber', function() {
+  var coEmptyNumberFilter,
+      defaultText = '&ndash;';
+
+  // Load the module.
+  beforeEach(module('coreos.filters'));
+
+  // Initialize the controller and a mock scope
+  beforeEach(inject(function(_coEmptyNumberFilter_) {
+    coEmptyNumberFilter = _coEmptyNumberFilter_;
+  }));
+
+  it('returns default text when null', function() {
+    expect(coEmptyNumberFilter(null)).toBe(defaultText);
+  });
+
+  it('returns default text when undefined', function() {
+    expect(coEmptyNumberFilter(undefined)).toBe(defaultText);
+  });
+
+  it('returns default text when NaN', function() {
+    expect(coEmptyNumberFilter(NaN)).toBe(defaultText);
+  });
+
+  it('returns actual value when zero', function() {
+    expect(coEmptyNumberFilter(0)).toBe('0');
+  });
+
+  it('returns actual value when non-zero', function() {
+    expect(coEmptyNumberFilter(1)).toBe('1');
+  });
+
+  it('returns actual value when less than zero', function() {
+    expect(coEmptyNumberFilter(-1)).toBe('-1');
+  });
+
+  it('returns a custom default text', function() {
+    expect(coEmptyNumberFilter(null, 'custom')).toBe('custom');
+  });
+
+});


### PR DESCRIPTION
...n empty
