### PR TITLE
feat(common/base): hide ng-cloak'd elements

### DIFF
--- a/src/sass/common/overrides/_base.scss
+++ b/src/sass/common/overrides/_base.scss
@@ -52,3 +52,7 @@ dl {
 .glyphicon {
   color: $color-icon-light;
 }
+
+[ng-cloak] {
+  display: none;
+}


### PR DESCRIPTION
Fixes item flashing on load.
