### PR TITLE
build: stop minifying css

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -183,14 +183,6 @@ module.exports = function(grunt) {
       }
     },
 
-    cssmin: {
-      dist: {
-        files: {
-          'dist/coreos.min.css': ['dist/coreos.css']
-        }
-      }
-    },
-
     uglify: {
       dist: {
         files: {
@@ -341,7 +333,6 @@ module.exports = function(grunt) {
     'test',
     'sass',
     'concat',
-    'cssmin',
     'ngmin',
     'uglify',
     'version',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "grunt-contrib-concat": "latest",
     "grunt-contrib-jshint": "0.8.0",
     "grunt-contrib-uglify": "latest",
-    "grunt-contrib-cssmin": "latest",
     "grunt-contrib-watch": "latest",
     "grunt-karma": "~0.8.0",
     "karma-jasmine": "~0.1.5",


### PR DESCRIPTION
the minifier had bugs, and after running some benchmarks im not completely convinced it's doing given the trivial savings in file size.
