### PR TITLE
Fixed path for bootstrap-sass.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -115,7 +115,7 @@ gulp.task('sass', function () {
     // Bootstrap
     var bootstrapStream = gulp.src('ext/style/bootstrap/bootstrap.scss')
       .pipe(sass({
-        includePaths: ['bower_components/bootstrap-sass/lib', 'src/sass'],
+        includePaths: ['bower_components/bootstrap-sass/assets/stylesheets/bootstrap', 'src/sass'],
         outputStyle: 'nested'
       }))
       .pipe(gulp.dest('dist'));


### PR DESCRIPTION
This fixes the issue with running gulp dev on a fresh coreos-web repo.