### PR TITLE
css: fix issue with modal backdrop not displaying

### DIFF
--- a/src/sass/common/overrides/_modal.scss
+++ b/src/sass/common/overrides/_modal.scss
@@ -19,3 +19,8 @@
   text-align: left;
   margin: 0px;
 }
+
+// HACK(sym3tri): fixes incompatibility between anguarl-bootstrap and latest bootstrap.
+.modal-backdrop {
+  height: 10000px;
+}


### PR DESCRIPTION
adds a temporary hack fix to the modal backdrop until angular-bootstrap is updated to work with latest boostrap.