### PR TITLE
table-grid: allow for wrappers around table rows, bodies, etc

### DIFF
--- a/src/ui/table-grid/_table-grid.scss
+++ b/src/ui/table-grid/_table-grid.scss
@@ -30,11 +30,11 @@
 }
 
 // Default row padding
-.co-m-table-grid > .co-m-table-grid__body > .row {
+.co-m-table-grid .co-m-table-grid__body .row {
   padding: 10px 0;
 }
 
-.co-m-table-grid--compact > .co-m-table-grid__body > .row {
+.co-m-table-grid--compact .co-m-table-grid__body .row {
   padding: 5px 0;
 }
 
@@ -45,8 +45,8 @@
 }
 
 .co-m-table-grid--bordered {
-  > .co-m-table-grid__head,
-  > .co-m-table-grid__body > .row {
+  .co-m-table-grid__head,
+  .co-m-table-grid__body .row {
     border-bottom: solid 1px $color-table-border;
   }
 }


### PR DESCRIPTION
This allows for angular-friendly constructions like
```html
<div class="co-m-table-grid">
    <div ng-if="predicate">
        ....
    </div>
    <div ng-if="!predicate">
        ....
    </div>
</div>
```